### PR TITLE
Bug Fix: Fixed install url for homebrew

### DIFF
--- a/installer
+++ b/installer
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 echo "installing homebrew"
-ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go)"
+ruby -e "$(curl -fsSL https://raw.github.com/mxcl/homebrew/go/install)"
 brew doctor
 brew update
 


### PR DESCRIPTION
According to the installation instructions here: http://brew.sh/ the
correct url for installing homebrew is https://raw.github.com/mxcl/homebrew/go/install
