### PR TITLE
Feature: Added homebrew-cask and chrome, iterm and alfred

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ What it sets up
 * Custom dotfiles (ZSH specific)
 * Vim 7.4 and jedi installed globally for improved python auto complete
 * Exuberant Ctags for indexing files for vim tab completion
+* Google Chrome
+* Alfred
+* iTerm2
 
 It usually takes around 60 minutes to install (depending on your hardware)
 

--- a/installer
+++ b/installer
@@ -64,6 +64,19 @@ echo "add GNU gettext and gettext-tools for django compile messages"
 brew install gettext
 brew link gettext --force
 
+echo "Setting up homebrew-cask"
+brew tap phinze/homebrew-cask
+brew install brew-cask
+
+echo "install chrome"
+brew cask install google-chrome
+
+echo "install iterm2"
+brew cask install iterm2
+
+echo "install alfred"
+brew cask install alfred
+
 echo "change the default shell to zsh"
 chsh -s /bin/zsh
 


### PR DESCRIPTION
Homebrew Cask (https://github.com/phinze/homebrew-cask) provides a way
to install a majority of other OS X applications that are not normally
installable via homebrew.
